### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,15 +8,15 @@ django-thumbnailfield
     :target: https://coveralls.io/r/lambdalisue/django-thumbnailfield/
     :alt: Coverage
 
-.. image:: https://pypip.in/d/django-thumbnailfield/badge.png
+.. image:: https://img.shields.io/pypi/dm/django-thumbnailfield.svg
     :target: https://pypi.python.org/pypi/django-thumbnailfield/
     :alt: Downloads
 
-.. image:: https://pypip.in/v/django-thumbnailfield/badge.png
+.. image:: https://img.shields.io/pypi/v/django-thumbnailfield.svg
     :target: https://pypi.python.org/pypi/django-thumbnailfield/
     :alt: Latest version
 
-.. image:: https://pypip.in/wheel/django-thumbnailfield/badge.png
+.. image:: https://img.shields.io/pypi/wheel/django-thumbnailfield.svg
     :target: https://pypi.python.org/pypi/django-thumbnailfield/
     :alt: Wheel Status
 
@@ -24,7 +24,7 @@ django-thumbnailfield
     :target: https://pypi.python.org/pypi/django-thumbnailfield/
     :alt: Egg Status
 
-.. image:: https://pypip.in/license/django-thumbnailfield/badge.png
+.. image:: https://img.shields.io/pypi/l/django-thumbnailfield.svg
     :target: https://pypi.python.org/pypi/django-thumbnailfield/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-thumbnailfield))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-thumbnailfield`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.